### PR TITLE
suppress ruby warnings

### DIFF
--- a/rdictcc.rb
+++ b/rdictcc.rb
@@ -228,7 +228,7 @@ class RDictCcDatabaseBuilder
     w = phrase.gsub(/(\([^(]*\)|\{[^{]*\}|\[[^\[]*\])/, '').strip.downcase
     return nil if w.empty? # No empty strings
     # Now return the longest word, hoping that it's the most important, too
-    ary = w.gsub(/[.,-<>]/, ' ').strip.split do |w| w.strip! end
+    ary = w.gsub(/[.,\-<>]/, ' ').strip.split do |i| i.strip! end
     ary.sort!{ |x,y| y.length <=> x.length }
     ary[0] # The longest element is the first
   end


### PR DESCRIPTION
deal with these warnings:
  rdictcc.rb:231: warning: character class has duplicated range: /[.,-<>]/
  rdictcc.rb:231: warning: shadowing outer local variable - w
